### PR TITLE
Fix lodash vulns

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "private": true,
   "dependencies": {
-    "@craco/craco": "^3.5.0",
+    "@craco/craco": "^5.2.3",
     "@textile/js-http-client": "0.2.11",
     "ed25519": "0.0.4",
     "electron-is-dev": "^1.1.0",
@@ -23,7 +23,7 @@
     "react-markdown-it": "^1.0.2",
     "react-medium-editor": "^1.8.1",
     "react-moment": "^0.8.4",
-    "react-scripts": "2.1.5",
+    "react-scripts": "3.0.1",
     "react-semantic-toasts": "^0.5.0",
     "react-shortcuts": "^2.0.1",
     "react-textarea-autosize": "^7.1.0",

--- a/src/Editor.tsx
+++ b/src/Editor.tsx
@@ -15,7 +15,7 @@ import { Emoji, Picker, emojiIndex } from 'emoji-mart'
 import { renderToString } from 'react-dom/server'
 // @ts-ignore
 import CodeMirror from 'react-codemirror'
-require('codemirror/lib/codemirror.css');
+import 'codemirror/lib/codemirror.css'
 // @ts-ignore
 import Showdown from 'showdown'
 // @ts-ignore


### PR DESCRIPTION
⚠️ ⚠️  Not ready to be merged

- [Lodash mergeWith](https://github.com/Permaweb/Permaweb-js/network/alert/yarn.lock/lodash.mergewith/open)
- [Lodash template](https://github.com/Permaweb/Permaweb-js/network/alert/yarn.lock/lodash.template/open)

Checks:
- [ ] Vulns were actually removed
  - [x] Updating craco removed `lodash.mergeWith` vuln
  - [ ] Updating react-scripts removed `lodash.tempalte` vuln - no, need to wait till they update & release
- [x] Can start dev environment
- [x] Can build
- [ ] Can pack/dist
