### PR TITLE
Custom trigger toolbar improvements

### DIFF
--- a/src/Editor.tsx
+++ b/src/Editor.tsx
@@ -134,7 +134,9 @@ class ArticleForm extends Component<ArticleForm> {
             getRangeAt: () => ({
               getBoundingClientRect: () => {
                 // @ts-ignore
-                const [{ left, top }] = window.getSelection().getRangeAt(0).cloneRange().getClientRects()
+                const { left: leftDefault } = self.wrapper.getBoundingClientRect()
+                // @ts-ignore
+                const [{ left, top } = { left: leftDefault, top: event.clientY }] = window.getSelection().getRangeAt(0).cloneRange().getClientRects()
                 const { bottom, height, right } = event.target.getBoundingClientRect()
                 return { bottom, height, left, top, right, width: 0 }
               }


### PR DESCRIPTION
WIP.
Pending:
- [ ] Return focus to editor after clicking on button
- [ ] Bug: clicks on top and bottom of editor (toolbar is not being positioned correctly)
- [ ] Bug: clicking on the icon for Emojis makes the caret move to the next line

How to test:
```
cd Permaweb-js
git fetch
git checkout feature/custom-trigger-toolbar-improvements
yarn start
```
Reminder: `textile daemon` should be running
Open up a browser to http://localhost:3000 and test out the new toolbar